### PR TITLE
Absorb the difference in language specification

### DIFF
--- a/src/Element/ArgumentElement.php
+++ b/src/Element/ArgumentElement.php
@@ -8,8 +8,12 @@ class ArgumentElement extends AbstractNamedElement implements EncodableInterface
 {
     const TYPE = 'parameter';
 
-    private static $excludeDataTypeMap = [
-        'variable'
+    private static $dataTypeConvertMap = [
+        'variable' => null,
+        'object' => null,
+        'resource' => null,
+        'long'     => 'int',
+        'double'   => 'float',
     ];
 
     private $dataType = null;
@@ -67,7 +71,9 @@ class ArgumentElement extends AbstractNamedElement implements EncodableInterface
         }
 
         $data_type = $params['data-type'] ?? null;
-        if (! in_array($data_type, self::$excludeDataTypeMap)) {
+        if (array_key_exists($data_type, self::$dataTypeConvertMap)) {
+            $ret->dataType = self::$dataTypeConvertMap[$data_type];
+        } else {
             $ret->dataType = $data_type;
         }
 

--- a/src/Element/MethodElement.php
+++ b/src/Element/MethodElement.php
@@ -197,6 +197,7 @@ class MethodElement extends AbstractNamedElement implements EncodableInterface, 
                     break;
 
                 case 'toString':
+                case '__toString':
                     $elem = new self();
                     $elem->name = '__toString';
                     $ret[] = $elem;

--- a/src/Element/NamespaceElement.php
+++ b/src/Element/NamespaceElement.php
@@ -166,8 +166,14 @@ class NamespaceElement extends AbstractNamedElement implements EncodableInterfac
     {
         $content = 'namespace ' . $this->getName() . "\n{\n";
 
+        $exclude_map = [];
+        foreach ($this->classes as $class) {
+            $exclude_map[] = $class->getName();
+        }
+
         foreach ($this->uses as $use) {
-            $content .= Util::indent($use->encode());
+            $content .= Util::indent($use->setExcludeConflictMap($exclude_map)->encode());
+            $exclude_map = array_merge($exclude_map, $use->getUniqueNames());
         }
 
         if (count($this->uses)) {

--- a/src/Element/UseElement.php
+++ b/src/Element/UseElement.php
@@ -68,7 +68,9 @@ class UseElement implements EncodableInterface
             }
 
             $content = $aliase['name'];
-            $unique_name = end(explode('\\', $aliase['name']));
+
+            $name_separated = explode('\\', $aliase['name']);
+            $unique_name = end($name_separated);
 
             if (! empty($aliase['alias'])) {
                 $content .= ' as ' . $aliase['alias'];

--- a/src/Element/UseElement.php
+++ b/src/Element/UseElement.php
@@ -14,11 +14,36 @@ class UseElement implements EncodableInterface
     private $aliases = [];
 
     /**
+     * @var string[]
+     */
+    private $uniqueNames = [];
+
+    private $excludeConflictMap = [];
+
+    /**
+     * @param array $exclude_conflict_map
+     * @return self
+     */
+    public function setExcludeConflictMap(array $exclude_conflict_map): self
+    {
+        $this->excludeConflictMap = $exclude_conflict_map;
+        return $this;
+    }
+
+    /**
      * @return string[]
      */
     public function getAliases(): array
     {
         return $this->aliases;
+    }
+
+    /**
+     * @var string[]
+     */
+    public function getUniqueNames(): array
+    {
+        return $this->uniqueNames;
     }
 
     /**
@@ -43,12 +68,15 @@ class UseElement implements EncodableInterface
             }
 
             $content = $aliase['name'];
+            $unique_name = end(explode('\\', $aliase['name']));
 
             if (! empty($aliase['alias'])) {
                 $content .= ' as ' . $aliase['alias'];
+                $unique_name = $aliase['alias'];
             }
 
             $ret->aliases[] = $content;
+            $ret->uniqueNames[] = $unique_name;
         }
 
         if (empty($ret->aliases)) {
@@ -64,6 +92,19 @@ class UseElement implements EncodableInterface
      */
     public function encode(): string
     {
-        return 'use ' . implode(', ', $this->getAliases()) . ";\n";
+        $aliases = $this->getAliases();
+
+        foreach ($this->uniqueNames as $key => $unique_name) {
+            if (in_array($unique_name, $this->excludeConflictMap)) {
+                unset($aliases[$key]);
+            }
+        }
+
+
+        if (! count($aliases)) {
+            return '';
+        }
+
+        return 'use ' . implode(', ', $aliases) . ";\n";
     }
 }


### PR DESCRIPTION
* convert Type System miss match 
* support old version shortcut (`__toString()`)
* Avoid double use (Zephir...OK PHP...NG) 
* Avoid collision of the use statement and class or interface name(Zephir...OK PHP...NG)